### PR TITLE
Update index.js rPI Null Value Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,8 +291,12 @@ KodiPlatform.prototype = {
     updateKodiPlayer: async function () {
         connection.kodiRequest(this.config, "Player.GetProperties", { "playerid": 1, "properties": ["speed", "percentage"] })
             .then(result => {
-                let speed = result.speed != 0;
-                let percentage = Math.round(result.percentage);
+                // On OSMC rPi the below was returning an null value error so added null value handling as done with unknown result.item.type below
+                // let speed = result.speed != 0;
+                let speed = result.speed != 0 ? result.speed : 0;
+                // let percentage = Math.round(result.percentage);
+                let percentage = result.percentage != 0 ? result.percentage : 0;
+                percentage = Math.round(percentage);
                 playerLightbulbService.getCharacteristic(Characteristic.On).updateValue(speed);
                 playerLightbulbService.getCharacteristic(Characteristic.Brightness).updateValue(percentage);
                 playerPlaySwitchService.getCharacteristic(Characteristic.On).updateValue(speed);


### PR DESCRIPTION
// On OSMC rPi the below was returning an null value error so added null value handling as done with unknown result.item.type below
// let speed = result.speed != 0;
let speed = result.speed != 0 ? result.speed : 0;
// let percentage = Math.round(result.percentage);
let percentage = result.percentage != 0 ? result.percentage : 0;
percentage = Math.round(percentage);

I am not a JS dev though so struggling my way around this stuff just know Python and Kodi stuff. 

I still get errors but not related to null value now,
TypeError: Cannot read property 'getCharacteristic' of undefined
    at connection.kodiRequest.then.result (/usr/lib/node_modules/homebridge-kodi/index.js:302:42)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)

